### PR TITLE
include option to skip the @data slot

### DIFF
--- a/R/Utils.R
+++ b/R/Utils.R
@@ -82,7 +82,7 @@ SeuratToAnnData <- function(seuratObj, outFileBaseName, assayName = NULL, export
     origAssay <- seuratObj@assays[[assayName]]
     seuratObj <- Seurat::CreateSeuratObject(counts = origAssay@counts, assay = assayName, project = seuratObj@project.name, meta.data = seuratObj@meta.data)
     if (includeData){
-    seuratObj <- Seurat::SetAssayData(seuratObj, assay = assayName, slot = 'data', new.data = origAssay@data)
+      seuratObj <- Seurat::SetAssayData(seuratObj, assay = assayName, slot = 'data', new.data = origAssay@data)
     }
   }
 

--- a/R/Utils.R
+++ b/R/Utils.R
@@ -63,7 +63,7 @@ SetAtlasDir <- function(folderPath) {
   return(parentFolder)
 }
 
-SeuratToAnnData <- function(seuratObj, outFileBaseName, assayName = NULL, exportMinimalObject = FALSE, allowableMetaCols = NULL) {
+SeuratToAnnData <- function(seuratObj, outFileBaseName, assayName = NULL, exportMinimalObject = FALSE, allowableMetaCols = NULL, includeData = TRUE) {
   tmpFile <- outFileBaseName
   if (!is.null(assayName)) {
     for (an in names(seuratObj@assays)) {
@@ -81,7 +81,9 @@ SeuratToAnnData <- function(seuratObj, outFileBaseName, assayName = NULL, export
     # NOTE: clone a new object to ensure we only carry forward the minimal data we need:
     origAssay <- seuratObj@assays[[assayName]]
     seuratObj <- Seurat::CreateSeuratObject(counts = origAssay@counts, assay = assayName, project = seuratObj@project.name, meta.data = seuratObj@meta.data)
+    if (includeData){
     seuratObj <- Seurat::SetAssayData(seuratObj, assay = assayName, slot = 'data', new.data = origAssay@data)
+    }
   }
 
   seuratObj@misc <- list()


### PR DESCRIPTION
Hi everyone, 

SaveH5Seurat seems to only save the current/most recently added slot into the AnnData file rather than saving all of the slots as equivalent AnnData layers. This seems to be a long-standing issue (see: https://github.com/mojaveazure/seurat-disk/issues/87) but I think we can skirt it by just including the slot we want specifically. 

@gboggy is intending to do a significant amount of preprocessing in scanpy for CoNGA, so it's necessary to be able to expose the counts slot here. 

Thanks!


